### PR TITLE
Make sure the real epoch count is consistent with epoch count config

### DIFF
--- a/sui/sources/movescription.move
+++ b/sui/sources/movescription.move
@@ -19,7 +19,7 @@ module smartinscription::movescription {
 
 
     // ======== Constants =========
-    const VERSION: u64 = 1;
+    const VERSION: u64 = 2;
     const MAX_TICK_LENGTH: u64 = 32;
     const MIN_TICK_LENGTH: u64 = 4;
     const MAX_MINT_FEE: u64 = 100_000_000_000;
@@ -250,7 +250,7 @@ module smartinscription::movescription {
         clk: &Clock,
         ctx: &mut TxContext
     ) {
-        assert!(deploy_record.version == VERSION, EVersionMismatched);
+        assert!(deploy_record.version <= VERSION, EVersionMismatched);
         let now_ms = clock::timestamp_ms(clk);
         if(start_time_ms == 0){
             start_time_ms = now_ms;
@@ -346,7 +346,7 @@ module smartinscription::movescription {
         clk: &Clock,
         ctx: &mut TxContext
     ) {
-        assert!(tick_record.version == VERSION, EVersionMismatched);
+        assert!(tick_record.version <= VERSION, EVersionMismatched);
         to_uppercase(&mut tick);
         let tick_str: String = string(tick);
         assert!(tick_record.tick == tick_str, ErrorTickNotExists);  // parallel optimization
@@ -508,6 +508,22 @@ module smartinscription::movescription {
     // Interface reserved for future SFT transactions
     public fun inject_sui(inscription: &mut Movescription, receive: Coin<SUI>) {
         coin::put(&mut inscription.acc, receive);
+    }
+
+    public entry fun inject_sui_entry(inscription: &mut Movescription, receive: Coin<SUI>) {
+        inject_sui(inscription, receive);
+    }
+
+    // ===== Migrate functions =====
+
+    public fun migrate_deploy_record(deploy_record: &mut DeployRecord) {
+        assert!(deploy_record.version <= VERSION, EVersionMismatched);
+        deploy_record.version = VERSION;
+    }
+
+    public fun migrate_tick_record(tick_record: &mut TickRecord) {
+        assert!(tick_record.version <= VERSION, EVersionMismatched);
+        tick_record.version = VERSION;
     }
 
     // ======== Movescription Read Functions =========

--- a/sui/sources/movescription.move
+++ b/sui/sources/movescription.move
@@ -406,6 +406,8 @@ module smartinscription::movescription {
             let remainder = epoch_amount - real_epoch_amount;
             let ins: Movescription = new_movescription(remainder, tick, balance::zero<SUI>(), option::none(), ctx);
             transfer::public_transfer(ins, settle_user);
+            tick_record.remain = tick_record.remain - remainder;
+            tick_record.current_supply = tick_record.current_supply + remainder;
         };
         // The mint_fees should be empty, this should not happen, add assert for debug
         // We can remove this assert after we are sure there is no bug

--- a/sui/sources/tests/test_movescription.move
+++ b/sui/sources/tests/test_movescription.move
@@ -100,6 +100,7 @@ module smartinscription::test_movescription {
                 let test_tick_record = test_scenario::take_shared<movescription::TickRecord>(scenario);
                 if (movescription::tick_record_remain(&test_tick_record) == 0) {
                     assert!(movescription::tick_record_current_supply(&test_tick_record) == total_supply, 1);
+                    assert!(movescription::tick_record_current_epoch(&test_tick_record) == movescription::tick_record_epoch_count(&test_tick_record)-1, 2);
                     test_scenario::return_shared(test_tick_record);
                     break
                 };


### PR DESCRIPTION
Make sure the real epoch count is consistent with the epoch count config.

1. Reward each epoch remainder to the settle user.
2. The last epoch amount includes the total_supply/epoch_count remainder.


Include #38 
