### PR TITLE
Upgrade burn function

### DIFF
--- a/sui/sources/movescription.move
+++ b/sui/sources/movescription.move
@@ -132,8 +132,8 @@ module smartinscription::movescription {
     struct BurnTick has copy, drop {
         sender: address,
         amount: u64,
-        for: address,
         message: string::String,
+        for: Option<address>,
     }
 
     struct NewEpoch has copy, drop {
@@ -477,9 +477,9 @@ module smartinscription::movescription {
 
     public fun do_burn_v2(
         tick_record: &mut TickRecord,
-        inscription: Movescription,
-        for: address,
+        inscription: Movescription,        
         message: vector<u8>,
+        for: Option<address>,
         ctx: &mut TxContext
     ) : (Coin<SUI>, BurnReceipt) {
         assert!(tick_record.version == VERSION, EVersionMismatched);
@@ -498,9 +498,9 @@ module smartinscription::movescription {
         emit({
             BurnTick {
                 sender: tx_context::sender(ctx),
-                amount: amount,
-                for: for,
+                amount: amount,                
                 message: string::utf8(message),
+                for: for,
             }
         });
 
@@ -519,12 +519,12 @@ module smartinscription::movescription {
     #[lint_allow(self_transfer)]
     public entry fun burn_v2(
         tick_record: &mut TickRecord,
-        inscription: Movescription,
-        for: address,
+        inscription: Movescription,        
         message: vector<u8>,
+        for: Option<address>,
         ctx: &mut TxContext
     ) {
-        let (acc, receipt) = do_burn_v2(tick_record, inscription, for, message, ctx);
+        let (acc, receipt) = do_burn_v2(tick_record, inscription, message, for, ctx);
         transfer::public_transfer(acc, tx_context::sender(ctx));
         transfer::public_transfer(receipt, tx_context::sender(ctx));
     }

--- a/sui/sources/movescription.move
+++ b/sui/sources/movescription.move
@@ -133,7 +133,6 @@ module smartinscription::movescription {
         sender: address,
         amount: u64,
         message: string::String,
-        for: Option<address>,
     }
 
     struct NewEpoch has copy, drop {
@@ -479,7 +478,6 @@ module smartinscription::movescription {
         tick_record: &mut TickRecord,
         inscription: Movescription,        
         message: vector<u8>,
-        for: Option<address>,
         ctx: &mut TxContext
     ) : (Coin<SUI>, BurnReceipt) {
         assert!(tick_record.version == VERSION, EVersionMismatched);
@@ -500,7 +498,6 @@ module smartinscription::movescription {
                 sender: tx_context::sender(ctx),
                 amount: amount,                
                 message: string::utf8(message),
-                for: for,
             }
         });
 
@@ -521,10 +518,9 @@ module smartinscription::movescription {
         tick_record: &mut TickRecord,
         inscription: Movescription,        
         message: vector<u8>,
-        for: Option<address>,
         ctx: &mut TxContext
     ) {
-        let (acc, receipt) = do_burn_v2(tick_record, inscription, message, for, ctx);
+        let (acc, receipt) = do_burn_v2(tick_record, inscription, message, ctx);
         transfer::public_transfer(acc, tx_context::sender(ctx));
         transfer::public_transfer(receipt, tx_context::sender(ctx));
     }

--- a/sui/sources/tests/test_movescription.move
+++ b/sui/sources/tests/test_movescription.move
@@ -119,7 +119,7 @@ module smartinscription::test_movescription {
             let test_tick_record = test_scenario::take_shared<movescription::TickRecord>(scenario);
             let first_inscription = test_scenario::take_from_sender<Movescription>(scenario);
             let amount = movescription::amount(&first_inscription);
-            movescription::burn(&mut test_tick_record, first_inscription, test_scenario::ctx(scenario));
+            movescription::burn_v2(&mut test_tick_record, first_inscription, usera, b"love and peace", test_scenario::ctx(scenario));
             assert!(movescription::tick_record_current_supply(&test_tick_record) == total_supply - amount, 1);
             test_scenario::return_shared(test_tick_record); 
         };

--- a/sui/sources/tests/test_movescription.move
+++ b/sui/sources/tests/test_movescription.move
@@ -1,5 +1,6 @@
 #[test_only]
 module smartinscription::test_movescription {
+    use std::option;
     use sui::clock;
     use sui::sui::SUI;
     use sui::coin;
@@ -119,7 +120,7 @@ module smartinscription::test_movescription {
             let test_tick_record = test_scenario::take_shared<movescription::TickRecord>(scenario);
             let first_inscription = test_scenario::take_from_sender<Movescription>(scenario);
             let amount = movescription::amount(&first_inscription);
-            movescription::burn_v2(&mut test_tick_record, first_inscription, usera, b"love and peace", test_scenario::ctx(scenario));
+            movescription::burn_v2(&mut test_tick_record, first_inscription, b"love and peace", option::some<address>(usera),test_scenario::ctx(scenario));
             assert!(movescription::tick_record_current_supply(&test_tick_record) == total_supply - amount, 1);
             test_scenario::return_shared(test_tick_record); 
         };

--- a/sui/sources/tests/test_movescription.move
+++ b/sui/sources/tests/test_movescription.move
@@ -120,7 +120,7 @@ module smartinscription::test_movescription {
             let test_tick_record = test_scenario::take_shared<movescription::TickRecord>(scenario);
             let first_inscription = test_scenario::take_from_sender<Movescription>(scenario);
             let amount = movescription::amount(&first_inscription);
-            movescription::burn_v2(&mut test_tick_record, first_inscription, b"love and peace", option::some<address>(usera),test_scenario::ctx(scenario));
+            movescription::burn_v2(&mut test_tick_record, first_inscription, b"love and peace", test_scenario::ctx(scenario));
             assert!(movescription::tick_record_current_supply(&test_tick_record) == total_supply - amount, 1);
             test_scenario::return_shared(test_tick_record); 
         };


### PR DESCRIPTION
升级铭文燃烧接口 burn 为 burn_v2.

更新点：

- `burn_v2` 接口新增一个参数：`message: vector<u8>`，定制化燃烧的消息；
- `burn_v2` 接口会触发 `BurnTick` 事件
- `burn_v2` 接口燃烧铭文后，交易发起人会收到一个 `BurnReceipt` NFT
-  原来的 `burn` 接口已经废弃
- 保留了 `do_burn` 接口，但仅作为内部使用，该接口不会触发事件和发送 NFT。比如 `deploy_v2` 发起的铭文燃烧就会调用此接口

Upgrade `burn` function to `burn_v2`.

What's new in `burn_v2`?

- Added an input parameter: `message: vector<u8>`, custom burning messages;
- The `burn_v2` function will trigger the `BurnTick` event
- `burn_v2` burns the inscription, the transaction sender will receive a `BurnReceipt` NFT
- The original `burn` function has been deprecated
- The `do_burn` interface is retained, but only for internal use, which does not trigger events and send NFT. For example, inscription burns triggered by `deploy_v2`  will call this function.