### PR TITLE
Burn for receipt

### DIFF
--- a/sui/sources/movescription.move
+++ b/sui/sources/movescription.move
@@ -53,6 +53,7 @@ module smartinscription::movescription {
     const EDeprecatedFunction: u64 = 20;
     const EInvalidFeeTick: u64 = 21;
     const ENotEnoughDeployFee: u64 = 22;
+    const ETemporarilyDisabled: u64 = 23;
 
     // ======== Types =========
     struct Movescription has key, store {
@@ -252,7 +253,7 @@ module smartinscription::movescription {
     }
 
     #[lint_allow(self_transfer)]
-    public entry fun deploy_v2(
+    fun do_deploy_with_fee(
         deploy_record: &mut DeployRecord,
         fee_tick_record: &mut TickRecord,
         fee_scription: &mut Movescription, 
@@ -281,6 +282,24 @@ module smartinscription::movescription {
         let deployer: address = tx_context::sender(ctx);
         transfer::public_transfer(acc_in_deploy_fee, deployer); 
         do_deploy(deploy_record, tick, total_supply, start_time_ms, epoch_count, mint_fee, ctx);
+    }
+
+    #[lint_allow(self_transfer)]
+    public entry fun deploy_v2(
+        _deploy_record: &mut DeployRecord,
+        _fee_tick_record: &mut TickRecord,
+        _fee_scription: &mut Movescription, 
+        _tick: vector<u8>,
+        _total_supply: u64,
+        _start_time_ms: u64,
+        _epoch_count: u64,
+        _mint_fee: u64,
+        _clk: &Clock,
+        _ctx: &mut TxContext
+    ) {
+        // Temporarily disable the deploy function for upgrade the protocol
+        abort ETemporarilyDisabled
+        //do_deploy_with_fee(_deploy_record, _fee_tick_record, _fee_scription, _tick, _total_supply, _start_time_ms, _epoch_count, _mint_fee, _clk, _ctx); 
     }
 
     public entry fun deploy(
@@ -684,6 +703,33 @@ module smartinscription::movescription {
     #[test_only]
     public fun init_for_testing(ctx: &mut TxContext) {
         init(MOVESCRIPTION{}, ctx);
+    }
+
+    #[test_only]
+    public fun deploy_with_fee_for_testing(
+        deploy_record: &mut DeployRecord,
+        fee_tick_record: &mut TickRecord,
+        fee_scription: &mut Movescription, 
+        tick: vector<u8>,
+        total_supply: u64,
+        start_time_ms: u64,
+        epoch_count: u64,
+        mint_fee: u64,
+        clk: &Clock,
+        ctx: &mut TxContext
+    ) {
+        do_deploy_with_fee(deploy_record, fee_tick_record, fee_scription, tick, total_supply, start_time_ms, epoch_count, mint_fee, clk, ctx);
+    }
+
+    #[test_only]
+    public fun new_movescription_for_testing(
+        amount: u64,
+        tick: String,
+        fee_balance: Balance<SUI>,
+        metadata: Option<Metadata>,
+        ctx: &mut TxContext
+    ) : Movescription {
+        new_movescription(amount, tick, fee_balance, metadata, ctx)
     }
 
     #[test]

--- a/sui/sources/movescription.move
+++ b/sui/sources/movescription.move
@@ -525,6 +525,13 @@ module smartinscription::movescription {
         (acc, receipt)
     }
 
+    /// Drop the BurnReceipt, allow developer to drop the receipt after the receipt is used
+    public fun drop_receipt(receipt: BurnReceipt):(String, u64) {
+        let BurnReceipt { id, tick: tick, amount: amount } = receipt;
+        object::delete(id);
+        (tick, amount)
+    }
+
     #[lint_allow(self_transfer)]
     /// Burn inscription and return the acc SUI to the sender
     public entry fun burn(

--- a/sui/sources/tests/test_movescription.move
+++ b/sui/sources/tests/test_movescription.move
@@ -119,8 +119,15 @@ module smartinscription::test_movescription {
             let test_tick_record = test_scenario::take_shared<movescription::TickRecord>(scenario);
             let first_inscription = test_scenario::take_from_sender<Movescription>(scenario);
             let amount = movescription::amount(&first_inscription);
-            movescription::burn_for_receipt(&mut test_tick_record, first_inscription, b"love and peace", test_scenario::ctx(scenario));
-            assert!(movescription::tick_record_current_supply(&test_tick_record) == total_supply - amount, 1);
+            let acc = movescription::acc(&first_inscription);
+            let tick = movescription::tick(&first_inscription);
+            let (coin, receipt) = movescription::do_burn_for_receipt(&mut test_tick_record, first_inscription, b"love and peace", test_scenario::ctx(scenario));
+            assert!(coin::value(&coin) == acc, 1);
+            transfer::public_transfer(coin, admin);
+            let (burn_tick, burn_amount) = movescription::drop_receipt(receipt);
+            assert!(tick == burn_tick, 2);
+            assert!(amount == burn_amount, 3);
+            assert!(movescription::tick_record_current_supply(&test_tick_record) == total_supply - amount, 4);
             test_scenario::return_shared(test_tick_record); 
         };
 

--- a/sui/sources/tests/test_movescription.move
+++ b/sui/sources/tests/test_movescription.move
@@ -1,6 +1,5 @@
 #[test_only]
 module smartinscription::test_movescription {
-    use std::option;
     use sui::clock;
     use sui::sui::SUI;
     use sui::coin;
@@ -120,7 +119,7 @@ module smartinscription::test_movescription {
             let test_tick_record = test_scenario::take_shared<movescription::TickRecord>(scenario);
             let first_inscription = test_scenario::take_from_sender<Movescription>(scenario);
             let amount = movescription::amount(&first_inscription);
-            movescription::burn_v2(&mut test_tick_record, first_inscription, b"love and peace", test_scenario::ctx(scenario));
+            movescription::burn_for_receipt(&mut test_tick_record, first_inscription, b"love and peace", test_scenario::ctx(scenario));
             assert!(movescription::tick_record_current_supply(&test_tick_record) == total_supply - amount, 1);
             test_scenario::return_shared(test_tick_record); 
         };

--- a/sui/sources/tests/test_movescription.move
+++ b/sui/sources/tests/test_movescription.move
@@ -43,7 +43,7 @@ module smartinscription::test_movescription {
             let deploy_record = test_scenario::take_shared<movescription::DeployRecord>(scenario);
             let now_ms = clock::timestamp_ms(&c);
             let tick = b"test";
-            movescription::deploy_v2(&mut deploy_record, &mut move_tick,&mut move_tick_scription, tick, total_supply, now_ms, epoch_count, 1000, &c, test_scenario::ctx(scenario));
+            movescription::deploy_with_fee_for_testing(&mut deploy_record, &mut move_tick,&mut move_tick_scription, tick, total_supply, now_ms, epoch_count, 1000, &c, test_scenario::ctx(scenario));
             test_scenario::return_shared(deploy_record);
             let after_deploy_move_tick_amount = movescription::amount(&move_tick_scription);
             assert!(start_move_tick_amount - after_deploy_move_tick_amount == movescription::calculate_deploy_fee(tick, epoch_count), 0);


### PR DESCRIPTION
1. Keep the original `burn` function and add new `burn_for_receipt` functions.
2. Add `tick` to `BurnTick` event.
3. Add `drop_receipt` for `BurnReceipt`.
4. Temporarily disable the deploy function for upgrade the protocol.
5. Add some test only functions.