### PR TITLE
Upgrade to v3

### DIFF
--- a/sui/Move.toml
+++ b/sui/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "SmartInscription"
 authors = ["Pika", "10xhunter", "jolestar", "jojoo-eth"]
-version = "0.0.1"
+version = "3.0.0"
 published-at = "0xebbba763f5fc01d90c2791c03536a373791b634600e81d4e08b85f275f1274fa"
 
 [dependencies]

--- a/sui/sources/movescription.move
+++ b/sui/sources/movescription.move
@@ -634,6 +634,22 @@ module smartinscription::movescription {
         movescription.attach_coin = movescription.attach_coin + 1;
     }
 
+    /// Borrow the `Value` type dof of the movescription
+    public fun borrow_dof<Value: key + store>(
+        movescription: &Movescription,
+    ): &Value {
+        let name = type_to_name<Value>();
+        dof::borrow<String, Value>(&movescription.id, name)
+    }
+
+    /// Borrow the `Value` type dof of the movescription mutably
+    public fun borrow_dof_mut<Value: key + store>(
+        movescription: &mut Movescription,
+    ): &mut Value {
+        let name = type_to_name<Value>();
+        dof::borrow_mut<String, Value>(&mut movescription.id, name)
+    }
+
     /// Returns the `Value` type dof of the movescription
     public fun remove_dof<Value: key + store>(
         movescription: &mut Movescription,

--- a/sui/sources/movescription.move
+++ b/sui/sources/movescription.move
@@ -21,7 +21,7 @@ module smartinscription::movescription {
 
 
     // ======== Constants =========
-    const VERSION: u64 = 2;
+    const VERSION: u64 = 3;
     const MAX_TICK_LENGTH: u64 = 32;
     const MIN_TICK_LENGTH: u64 = 4;
     const MAX_MINT_FEE: u64 = 100_000_000_000;

--- a/sui/sources/tests/movescription_object_test.move
+++ b/sui/sources/tests/movescription_object_test.move
@@ -107,32 +107,32 @@ module smartinscription::movescription_object_test{
     }
 
     #[test]
-    fun test_dof(){
+    fun test_df(){
         let tick = std::ascii::string(b"MOVE");
         let tx_context = tx_context::dummy();
         let acc_balance = balance::create_for_testing<SUI>(1000u64);
         let inscription_amount = 1000u64;
         let ms = movescription::new_movescription_for_testing(inscription_amount, tick, acc_balance, option::none(), &mut tx_context);
         let value = coin::mint_for_testing<SUI>(100u64, &mut tx_context);
-        movescription::add_dof(&mut ms, value);
-        assert!(movescription::exists_dof<Coin<SUI>>(&ms), 1);
-        assert!(movescription::contains_dof(&ms), 2);
-        assert!(movescription::attach_dof(&ms) == 1u64, 3);
+        movescription::add_df(&mut ms, value);
+        assert!(movescription::exists_df<Coin<SUI>>(&ms), 1);
+        assert!(movescription::contains_df(&ms), 2);
+        assert!(movescription::attach_df(&ms) == 1u64, 3);
         {
-            let dof = movescription::borrow_dof<Coin<SUI>>(&ms);
-            assert!(coin::value(dof) == 100u64, 4);
+            let df = movescription::borrow_df<Coin<SUI>>(&ms);
+            assert!(coin::value(df) == 100u64, 4);
         };
         {
             let c = coin::mint_for_testing<SUI>(100u64, &mut tx_context);
-            let dof = movescription::borrow_dof_mut<Coin<SUI>>(&mut ms);
-            coin::join(dof, c);
+            let df = movescription::borrow_df_mut<Coin<SUI>>(&mut ms);
+            coin::join(df, c);
         };
-        let new_value = movescription::remove_dof<Coin<SUI>>(&mut ms);
+        let new_value = movescription::remove_df<Coin<SUI>>(&mut ms);
         assert!(coin::value(&new_value) == 200u64, 4);
 
-        assert!(!movescription::exists_dof<Coin<SUI>>(&ms), 5);
-        assert!(!movescription::contains_dof(&ms), 6);
-        assert!(movescription::attach_dof(&ms) == 0u64, 7);
+        assert!(!movescription::exists_df<Coin<SUI>>(&ms), 5);
+        assert!(!movescription::contains_df(&ms), 6);
+        assert!(movescription::attach_df(&ms) == 0u64, 7);
 
         coin::burn_for_testing(new_value);
         movescription::drop_movescription_for_testing(ms);
@@ -140,14 +140,30 @@ module smartinscription::movescription_object_test{
 
     #[test]
     #[expected_failure]
-    fun test_dof_split_failed(){
+    fun test_repeat_df(){
         let tick = std::ascii::string(b"MOVE");
         let tx_context = tx_context::dummy();
         let acc_balance = balance::create_for_testing<SUI>(1000u64);
         let inscription_amount = 1000u64;
         let ms = movescription::new_movescription_for_testing(inscription_amount, tick, acc_balance, option::none(), &mut tx_context);
         let value = coin::mint_for_testing<SUI>(100u64, &mut tx_context);
-        movescription::add_dof(&mut ms, value);
+        movescription::add_df(&mut ms, value);
+        assert!(movescription::exists_df<Coin<SUI>>(&ms), 1);
+        let value2 = coin::mint_for_testing<SUI>(100u64, &mut tx_context);
+        movescription::add_df(&mut ms, value2);
+        movescription::drop_movescription_for_testing(ms);
+    }
+
+    #[test]
+    #[expected_failure]
+    fun test_df_split_failed(){
+        let tick = std::ascii::string(b"MOVE");
+        let tx_context = tx_context::dummy();
+        let acc_balance = balance::create_for_testing<SUI>(1000u64);
+        let inscription_amount = 1000u64;
+        let ms = movescription::new_movescription_for_testing(inscription_amount, tick, acc_balance, option::none(), &mut tx_context);
+        let value = coin::mint_for_testing<SUI>(100u64, &mut tx_context);
+        movescription::add_df(&mut ms, value);
         let split_amount = 100u64;
         let new_ms = movescription::do_split(&mut ms, split_amount, &mut tx_context);
         movescription::drop_movescription_for_testing(ms);
@@ -155,14 +171,14 @@ module smartinscription::movescription_object_test{
     }
 
     #[test]
-    fun test_dof_merge(){
+    fun test_df_merge(){
         let tick = std::ascii::string(b"MOVE");
         let tx_context = tx_context::dummy();
         let acc_balance = balance::create_for_testing<SUI>(1000u64);
         let inscription_amount = 1000u64;
         let ms = movescription::new_movescription_for_testing(inscription_amount, tick, acc_balance, option::none(), &mut tx_context);
         let value = coin::mint_for_testing<SUI>(100u64, &mut tx_context);
-        movescription::add_dof(&mut ms, value);
+        movescription::add_df(&mut ms, value);
         let acc_balance = balance::create_for_testing<SUI>(1000u64);
         let second_ms = movescription::new_movescription_for_testing(inscription_amount, tick, acc_balance, option::none(), &mut tx_context);
         movescription::do_merge(&mut ms, second_ms);
@@ -171,18 +187,18 @@ module smartinscription::movescription_object_test{
 
     #[test]
     #[expected_failure]
-    fun test_dof_merge_failed(){
+    fun test_df_merge_failed(){
         let tick = std::ascii::string(b"MOVE");
         let tx_context = tx_context::dummy();
         let acc_balance = balance::create_for_testing<SUI>(1000u64);
         let inscription_amount = 1000u64;
         let ms = movescription::new_movescription_for_testing(inscription_amount, tick, acc_balance, option::none(), &mut tx_context);
         let value = coin::mint_for_testing<SUI>(100u64, &mut tx_context);
-        movescription::add_dof(&mut ms, value);
+        movescription::add_df(&mut ms, value);
         let acc_balance = balance::create_for_testing<SUI>(1000u64);
         let second_ms = movescription::new_movescription_for_testing(inscription_amount, tick, acc_balance, option::none(), &mut tx_context);
         let value = coin::mint_for_testing<SUI>(100u64, &mut tx_context);
-        movescription::add_dof(&mut second_ms, value);
+        movescription::add_df(&mut second_ms, value);
         movescription::do_merge(&mut ms, second_ms);
         movescription::drop_movescription_for_testing(ms);
     }

--- a/sui/sources/tests/movescription_object_test.move
+++ b/sui/sources/tests/movescription_object_test.move
@@ -118,8 +118,17 @@ module smartinscription::movescription_object_test{
         assert!(movescription::exists_dof<Coin<SUI>>(&ms), 1);
         assert!(movescription::contains_dof(&ms), 2);
         assert!(movescription::attach_dof(&ms) == 1u64, 3);
+        {
+            let dof = movescription::borrow_dof<Coin<SUI>>(&ms);
+            assert!(coin::value(dof) == 100u64, 4);
+        };
+        {
+            let c = coin::mint_for_testing<SUI>(100u64, &mut tx_context);
+            let dof = movescription::borrow_dof_mut<Coin<SUI>>(&mut ms);
+            coin::join(dof, c);
+        };
         let new_value = movescription::remove_dof<Coin<SUI>>(&mut ms);
-        assert!(coin::value(&new_value) == 100u64, 4);
+        assert!(coin::value(&new_value) == 200u64, 4);
 
         assert!(!movescription::exists_dof<Coin<SUI>>(&ms), 5);
         assert!(!movescription::contains_dof(&ms), 6);

--- a/sui/sources/tests/movescription_object_test.move
+++ b/sui/sources/tests/movescription_object_test.move
@@ -1,0 +1,181 @@
+#[test_only]
+module smartinscription::movescription_object_test{
+
+    use std::option;
+    use sui::sui::SUI;
+    use sui::tx_context;
+    use sui::balance;
+    use sui::coin::{Self, Coin};
+    use smartinscription::movescription;
+
+    #[test]
+    fun test_calculate_deploy_fee(){
+        let fee = movescription::calculate_deploy_fee(b"MOVE", movescription::base_epoch_count());
+        assert!(fee == 1100, 0);
+        let fee = movescription::calculate_deploy_fee(b"MOVER", movescription::base_epoch_count());
+        assert!(fee == 900, 0);
+        let fee = movescription::calculate_deploy_fee(b"MMMMMMMMMMMMMMMMMMMMMMMMMMMMOVER", movescription::base_epoch_count());
+        assert!(fee == 225, 0);
+        let fee = movescription::calculate_deploy_fee(b"MOVE", 60*24);
+        //std::debug::print(&fee);
+        assert!(fee == 2500, 0);
+        let fee = movescription::calculate_deploy_fee(b"MOVE", movescription::min_epochs());
+        assert!(fee == 19000, 0); 
+        //std::debug::print(&fee);
+    }
+
+     #[test]
+    fun test_split_acc(){
+        let acc_balance = balance::create_for_testing<SUI>(1000u64);
+        let split_amount = 100u64;
+        let inscription_amount = 1000u64;
+        let tick = std::ascii::string(b"MOVE");
+        let tx_context = tx_context::dummy();
+        let ms = movescription::new_movescription_for_testing(inscription_amount, tick, acc_balance, option::none(), &mut tx_context);
+        let new_ms = movescription::do_split(&mut ms, split_amount, &mut tx_context);
+        let new_acc_amount = movescription::acc(&new_ms);
+        assert!(new_acc_amount == 100u64, 0);
+        movescription::drop_movescription_for_testing(ms);
+        movescription::drop_movescription_for_testing(new_ms);
+    }
+
+    #[test]
+    fun test_split_acc2(){
+        let acc_balance = balance::create_for_testing<SUI>(4_0000_0000u64);
+        let split_amount = 1111_1111u64;
+        let inscription_amount = 9999_9999u64;
+        let tick = std::ascii::string(b"MOVE");
+        let tx_context = tx_context::dummy();
+        let ms = movescription::new_movescription_for_testing(inscription_amount, tick, acc_balance, option::none(), &mut tx_context);
+        let new_ms = movescription::do_split(&mut ms, split_amount, &mut tx_context);
+        let new_acc_amount = movescription::acc(&new_ms);
+        assert!(new_acc_amount == 4444_4444u64, 0);
+        movescription::drop_movescription_for_testing(ms);
+        movescription::drop_movescription_for_testing(new_ms);
+    }
+
+    #[test]
+    fun test_split_acc3(){
+        let acc_balance = balance::create_for_testing<SUI>(100u64);
+        let split_amount = 1u64;
+        let inscription_amount = 100_0000u64;
+        let tick = std::ascii::string(b"MOVE");
+        let tx_context = tx_context::dummy();
+        let ms = movescription::new_movescription_for_testing(inscription_amount, tick, acc_balance, option::none(), &mut tx_context);
+        let new_ms = movescription::do_split(&mut ms, split_amount, &mut tx_context);
+        let new_acc_amount = movescription::acc(&new_ms);
+        //std::debug::print(&new_acc_amount);
+        assert!(new_acc_amount == 1u64, 0);
+        movescription::drop_movescription_for_testing(ms);
+        movescription::drop_movescription_for_testing(new_ms);
+    }
+
+    #[test]
+    fun test_merge(){
+        let tick = std::ascii::string(b"MOVE");
+        let tx_context = tx_context::dummy();
+        let first_acc_balance = balance::create_for_testing<SUI>(50u64);
+        let first_amount = 100u64;
+        let first_ms = movescription::new_movescription_for_testing(first_amount, tick, first_acc_balance, option::none(), &mut tx_context);
+        let second_acc_balance = balance::create_for_testing<SUI>(50u64);
+        let second_amount = 200u64;
+        let second_ms = movescription::new_movescription_for_testing(second_amount, tick, second_acc_balance, option::none(), &mut tx_context);
+        movescription::do_merge(&mut first_ms, second_ms);
+        let new_amount = movescription::amount(&first_ms);
+        assert!(new_amount == first_amount+second_amount, 0);
+
+        let new_acc_amount = movescription::acc(&first_ms);
+        assert!(new_acc_amount == 100u64, 0);
+
+        movescription::drop_movescription_for_testing(first_ms);
+    }
+
+    #[test]
+    #[expected_failure]
+    fun test_merge_different_movescription_failed(){
+        let tick1 = std::ascii::string(b"MOVE");
+        let tick2 = std::ascii::string(b"M0VE");
+        let tx_context = tx_context::dummy();
+        let first_acc_balance = balance::create_for_testing<SUI>(50u64);
+        let first_amount = 100u64;
+        let first_ms = movescription::new_movescription_for_testing(first_amount, tick1, first_acc_balance, option::none(), &mut tx_context);
+        let second_acc_balance = balance::create_for_testing<SUI>(50u64);
+        let second_amount = 200u64;
+        let second_ms = movescription::new_movescription_for_testing(second_amount, tick2, second_acc_balance, option::none(), &mut tx_context);
+        movescription::do_merge(&mut first_ms, second_ms);
+        movescription::drop_movescription_for_testing(first_ms);
+    }
+
+    #[test]
+    fun test_dof(){
+        let tick = std::ascii::string(b"MOVE");
+        let tx_context = tx_context::dummy();
+        let acc_balance = balance::create_for_testing<SUI>(1000u64);
+        let inscription_amount = 1000u64;
+        let ms = movescription::new_movescription_for_testing(inscription_amount, tick, acc_balance, option::none(), &mut tx_context);
+        let value = coin::mint_for_testing<SUI>(100u64, &mut tx_context);
+        movescription::add_dof(&mut ms, value);
+        assert!(movescription::exists_dof<Coin<SUI>>(&ms), 1);
+        assert!(movescription::contains_dof(&ms), 2);
+        assert!(movescription::attach_dof(&ms) == 1u64, 3);
+        let new_value = movescription::remove_dof<Coin<SUI>>(&mut ms);
+        assert!(coin::value(&new_value) == 100u64, 4);
+
+        assert!(!movescription::exists_dof<Coin<SUI>>(&ms), 5);
+        assert!(!movescription::contains_dof(&ms), 6);
+        assert!(movescription::attach_dof(&ms) == 0u64, 7);
+
+        coin::burn_for_testing(new_value);
+        movescription::drop_movescription_for_testing(ms);
+    }
+
+    #[test]
+    #[expected_failure]
+    fun test_dof_split_failed(){
+        let tick = std::ascii::string(b"MOVE");
+        let tx_context = tx_context::dummy();
+        let acc_balance = balance::create_for_testing<SUI>(1000u64);
+        let inscription_amount = 1000u64;
+        let ms = movescription::new_movescription_for_testing(inscription_amount, tick, acc_balance, option::none(), &mut tx_context);
+        let value = coin::mint_for_testing<SUI>(100u64, &mut tx_context);
+        movescription::add_dof(&mut ms, value);
+        let split_amount = 100u64;
+        let new_ms = movescription::do_split(&mut ms, split_amount, &mut tx_context);
+        movescription::drop_movescription_for_testing(ms);
+        movescription::drop_movescription_for_testing(new_ms);
+    }
+
+    #[test]
+    fun test_dof_merge(){
+        let tick = std::ascii::string(b"MOVE");
+        let tx_context = tx_context::dummy();
+        let acc_balance = balance::create_for_testing<SUI>(1000u64);
+        let inscription_amount = 1000u64;
+        let ms = movescription::new_movescription_for_testing(inscription_amount, tick, acc_balance, option::none(), &mut tx_context);
+        let value = coin::mint_for_testing<SUI>(100u64, &mut tx_context);
+        movescription::add_dof(&mut ms, value);
+        let acc_balance = balance::create_for_testing<SUI>(1000u64);
+        let second_ms = movescription::new_movescription_for_testing(inscription_amount, tick, acc_balance, option::none(), &mut tx_context);
+        movescription::do_merge(&mut ms, second_ms);
+        movescription::drop_movescription_for_testing(ms);
+    }
+
+    #[test]
+    #[expected_failure]
+    fun test_dof_merge_failed(){
+        let tick = std::ascii::string(b"MOVE");
+        let tx_context = tx_context::dummy();
+        let acc_balance = balance::create_for_testing<SUI>(1000u64);
+        let inscription_amount = 1000u64;
+        let ms = movescription::new_movescription_for_testing(inscription_amount, tick, acc_balance, option::none(), &mut tx_context);
+        let value = coin::mint_for_testing<SUI>(100u64, &mut tx_context);
+        movescription::add_dof(&mut ms, value);
+        let acc_balance = balance::create_for_testing<SUI>(1000u64);
+        let second_ms = movescription::new_movescription_for_testing(inscription_amount, tick, acc_balance, option::none(), &mut tx_context);
+        let value = coin::mint_for_testing<SUI>(100u64, &mut tx_context);
+        movescription::add_dof(&mut second_ms, value);
+        movescription::do_merge(&mut ms, second_ms);
+        movescription::drop_movescription_for_testing(ms);
+    }
+    
+}

--- a/sui/sources/tests/movescription_scenario_test.move
+++ b/sui/sources/tests/movescription_scenario_test.move
@@ -1,5 +1,5 @@
 #[test_only]
-module smartinscription::test_movescription {
+module smartinscription::movescription_scenario_test {
     use sui::clock;
     use sui::sui::SUI;
     use sui::coin;


### PR DESCRIPTION
1. Upgrade to v3
2. df 接口通过 Value 类型来区分，这样不同应用不会冲突。如果应用想用字符串作为 key，可以在 Value 中包含一个 Table 来实现。
3. 增加更多的测试用例。