### PR TITLE
Tick name factory

### DIFF
--- a/sui/Move.toml
+++ b/sui/Move.toml
@@ -12,7 +12,7 @@ Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-fram
 
 [addresses]
 #mainnet
-smartinscription = "0x830fe26674dc638af7c3d84030e2575f44a2bdc1baa1f4757cfe010a4b106b6a"
+#smartinscription = "0x830fe26674dc638af7c3d84030e2575f44a2bdc1baa1f4757cfe010a4b106b6a"
 #testnet
 #smartinscription = "0xde652a9bbdf6e34c39d3bb758e9010437ddacf8b5b03dae68e400034a03970e3"
-#smartinscription = "0x0"
+smartinscription = "0x0"

--- a/sui/sources/content_type.move
+++ b/sui/sources/content_type.move
@@ -1,0 +1,104 @@
+module smartinscription::content_type{
+    use std::string::{Self, String};
+    use smartinscription::movescription::{Self, Metadata};
+    use smartinscription::string_util;
+
+    const CONTENT_TYPE_TEXT_PLAIN: vector<u8>  = b"text/plain";
+    const CONTENT_TYPE_TEXT_HTML: vector<u8>  = b"text/html";
+    const CONTENT_TYPE_TEXT_CSS: vector<u8>  = b"text/css";
+    const CONTENT_TYPE_TEXT_JAVASCRIPT: vector<u8>  = b"text/javascript";
+    const CONTENT_TYPE_TEXT_XML: vector<u8>  = b"text/xml";
+
+    const CONTENT_TYPE_IMAGE_JPEG: vector<u8>  = b"image/jpeg";
+    const CONTENT_TYPE_IMAGE_PNG: vector<u8>  = b"image/png";
+    const CONTENT_TYPE_IMAGE_GIF: vector<u8>  = b"image/gif";
+    const CONTENT_TYPE_IMAGE_SVG: vector<u8>  = b"image/svg+xml";
+    const CONTENT_TYPE_IMAGE_BMP: vector<u8>  = b"image/bmp";
+    const CONTENT_TYPE_IMAGE_WEBP: vector<u8>  = b"image/webp";
+
+    const CONTENT_TYPE_APPLICATION_JSON: vector<u8>  = b"application/json";
+    const CONTENT_TYPE_APPLICATION_PDF: vector<u8>  = b"application/pdf";
+
+    public fun content_type_text_plain(): String{
+        string::utf8(CONTENT_TYPE_TEXT_PLAIN)
+    }
+
+    public fun content_type_text_html(): String{
+        string::utf8(CONTENT_TYPE_TEXT_HTML)
+    }
+
+    public fun content_type_text_css(): String{
+        string::utf8(CONTENT_TYPE_TEXT_CSS)
+    }
+
+    public fun content_type_text_javascript(): String{
+        string::utf8(CONTENT_TYPE_TEXT_JAVASCRIPT)
+    }
+
+    public fun content_type_text_xml(): String{
+        string::utf8(CONTENT_TYPE_TEXT_XML)
+    }
+
+    public fun content_type_image_jpeg(): String{
+        string::utf8(CONTENT_TYPE_IMAGE_JPEG)
+    }
+
+    public fun content_type_image_png(): String{
+        string::utf8(CONTENT_TYPE_IMAGE_PNG)
+    }
+
+    public fun content_type_image_gif(): String{
+        string::utf8(CONTENT_TYPE_IMAGE_GIF)
+    }
+
+    public fun content_type_image_svg(): String{
+        string::utf8(CONTENT_TYPE_IMAGE_SVG)
+    }
+
+    public fun content_type_image_bmp(): String{
+        string::utf8(CONTENT_TYPE_IMAGE_BMP)
+    }
+
+    public fun content_type_image_webp(): String{
+        string::utf8(CONTENT_TYPE_IMAGE_WEBP)
+    }
+
+    public fun content_type_application_json(): String{
+        string::utf8(CONTENT_TYPE_APPLICATION_JSON)
+    }
+
+    public fun content_type_application_pdf(): String{
+        string::utf8(CONTENT_TYPE_APPLICATION_PDF)
+    }
+
+    
+    public fun is_text(content_type: &String): bool{
+        string_util::starts_with(string::bytes(content_type), &b"text/") || string::bytes(content_type) == &CONTENT_TYPE_APPLICATION_JSON
+    }
+
+    public fun is_image(content_type: &String): bool{
+        string_util::starts_with(string::bytes(content_type), &b"image/")
+    }
+
+    public fun new_string_metadata(text: &String): Metadata{
+        movescription::new_metadata(content_type_text_plain(), *string::bytes(text))
+    }
+
+    public fun new_ascii_metadata(text: &std::ascii::String): Metadata{
+        movescription::new_metadata(content_type_text_plain(), *std::ascii::as_bytes(text))
+    }
+
+    #[test]
+    fun test_is_text(){
+        assert!(is_text(&string::utf8(b"text/plain")), 1);
+        assert!(is_text(&string::utf8(b"application/json")), 6);
+        assert!(!is_text(&string::utf8(b"image/jpeg")), 7);
+
+    }
+
+    #[test]
+    fun test_is_image(){
+        assert!(is_image(&string::utf8(b"image/jpeg")), 2);
+        assert!(!is_image(&string::utf8(b"text/plain")), 3); 
+    }
+}

--- a/sui/sources/movescription.move
+++ b/sui/sources/movescription.move
@@ -13,9 +13,12 @@ module smartinscription::movescription {
     use sui::clock::{Self, Clock};
     use sui::package;
     use sui::display;
+    use sui::dynamic_field as df;
     use smartinscription::string_util::{to_uppercase};
     use smartinscription::svg;
+    use smartinscription::type_util;
 
+    friend smartinscription::tick_factory;
 
     // ======== Constants =========
     const VERSION: u64 = 3;
@@ -52,6 +55,7 @@ module smartinscription::movescription {
     const EInvalidFeeTick: u64 = 21;
     const ENotEnoughDeployFee: u64 = 22;
     const ETemporarilyDisabled: u64 = 23;
+    const ErrorNotWitness: u64 = 24;
 
     // ======== Types =========
     struct Movescription has key, store {
@@ -87,6 +91,7 @@ module smartinscription::movescription {
     struct DeployRecord has key {
         id: UID,
         version: u64,
+        /// The Tick name -> TickRecord object id
         record: Table<String, address>,
     }
 
@@ -112,6 +117,27 @@ module smartinscription::movescription {
         total_transactions: u64,
     }
 
+    struct TickStat has store{
+        /// The remaining inscription amount not minted
+        remain: u64,
+        /// The current supply of the inscription, burn will decrease the current supply
+        current_supply: u64,
+        /// Total mint transactions
+        total_transactions: u64, 
+    }
+
+    struct TickRecordV2 has key, store {
+        id: UID,
+        version: u64,
+        tick: String,
+        total_supply: u64,
+        /// The initial locked Asset in the inscription
+        init_locked_asset: u64,
+        // The mint factory type name
+        mint_factory: String,
+        stat: TickStat,
+    }
+
     struct BurnReceipt has key, store {
         id: UID,
         tick: String,
@@ -127,6 +153,14 @@ module smartinscription::movescription {
         start_time_ms: u64,
         epoch_count: u64,
         mint_fee: u64,
+    }
+
+    struct DeployTickV2 has copy, drop {
+        id: ID,
+        deployer: address,
+        tick: String,
+        total_supply: u64,
+        init_locked_asset: u64,
     }
 
     struct MintTick has copy, drop {
@@ -470,6 +504,86 @@ module smartinscription::movescription {
         };
     }
 
+    public(friend) fun do_deploy_with_witness<W: drop>(
+        deploy_record: &mut DeployRecord, 
+        tick: String,
+        total_supply: u64,
+        init_locked_asset: u64,
+        _witness: W,
+        ctx: &mut TxContext
+    ) : TickRecordV2 {
+        //to_uppercase(&mut tick);
+        //let tick_str: String = string(tick);
+        //let tick_len: u64 = ascii::length(&tick_str);
+        //assert!(MIN_TICK_LENGTH <= tick_len && tick_len <= MAX_TICK_LENGTH, ErrorTickLengthInvaid);
+        assert!(!table::contains(&deploy_record.record, tick), ErrorTickAlreadyExists);
+        assert!(total_supply > 0, ENotEnoughSupply);
+        assert!(type_util::is_witness<W>(), ErrorNotWitness);
+
+        let mint_factory = type_util::module_id<W>();
+        let tick_uid = object::new(ctx);
+        let tick_id = object::uid_to_inner(&tick_uid);
+        let tick_record: TickRecordV2 = TickRecordV2 {
+            id: tick_uid,
+            version: VERSION,
+            tick: tick,
+            total_supply,
+            init_locked_asset,
+            mint_factory,
+            stat: TickStat {
+                remain: total_supply,
+                current_supply: 0,
+                total_transactions: 0,
+            },
+        };
+        let tk_record_address: address = object::id_address(&tick_record);
+        table::add(&mut deploy_record.record, tick, tk_record_address);
+        emit(DeployTickV2 {
+            id: tick_id,
+            deployer: tx_context::sender(ctx),
+            tick: tick,
+            total_supply,
+            init_locked_asset,
+        });
+        tick_record
+    }
+
+    #[lint_allow(self_transfer)]
+    public fun do_mint_with_witness<W: drop>(
+        tick_record: &mut TickRecordV2,
+        init_locked_coin: Coin<SUI>,
+        amount: u64,
+        metadata: Option<Metadata>,
+        _witness: W,
+        ctx: &mut TxContext
+    ) : Movescription {
+        assert!(tick_record.version <= VERSION, EVersionMismatched);
+        assert!(tick_record.stat.remain > amount, ENotEnoughToMint);
+        assert!(type_util::is_witness<W>(), ErrorNotWitness);
+        type_util::assert_witness<W>(tick_record.mint_factory);
+
+        tick_record.stat.remain = tick_record.stat.remain - amount;
+        tick_record.stat.current_supply = tick_record.stat.current_supply + amount;
+        tick_record.stat.total_transactions = tick_record.stat.total_transactions + 1;
+
+        let sender: address = tx_context::sender(ctx);
+        let tick: String = tick_record.tick;
+
+        let acc_coin = if(coin::value<SUI>(&init_locked_coin) == tick_record.init_locked_asset){
+            init_locked_coin
+        }else{
+            let acc_coin = coin::split<SUI>(&mut init_locked_coin, tick_record.init_locked_asset, ctx);
+            transfer::public_transfer(init_locked_coin, sender);
+            acc_coin
+        };
+        let init_acc_balance: Balance<SUI> = coin::into_balance<SUI>(acc_coin);
+        new_movescription(amount, tick, init_acc_balance, metadata, ctx)
+    }
+
+    public fun is_mergeable(inscription1: &Movescription, inscription2: &Movescription): bool {
+        inscription1.tick == inscription2.tick && inscription1.metadata == inscription2.metadata
+    }
+
     public fun do_merge(
         inscription1: &mut Movescription,
         inscription2: Movescription,
@@ -576,6 +690,10 @@ module smartinscription::movescription {
         transfer::public_transfer(acc, tx_context::sender(ctx));
         transfer::public_transfer(receipt, tx_context::sender(ctx));
     }
+    
+    public fun is_splitable(inscription: &Movescription): bool {
+        inscription.amount > 1 && inscription.attach_coin == 0
+    }
 
     public fun do_split(
         inscription: &mut Movescription,
@@ -637,6 +755,12 @@ module smartinscription::movescription {
         inscription.tick == tick_str
     }
 
+    public fun check_tick_record(tick_record: &TickRecordV2, tick: vector<u8>): bool {
+        to_uppercase(&mut tick);
+        let tick_str: String = string(tick);
+        tick_record.tick == tick_str
+    }
+
     // ===== Migrate functions =====
 
     public fun migrate_deploy_record(deploy_record: &mut DeployRecord) {
@@ -664,6 +788,18 @@ module smartinscription::movescription {
    
     public fun acc(inscription: &Movescription): u64 {
         balance::value(&inscription.acc)
+    }
+
+    public fun metadata(inscription: &Movescription): Option<Metadata> {
+        inscription.metadata
+    }
+
+    // ======== DeployRecord Read Functions =========
+
+    public fun is_deployed(deploy_record: &DeployRecord, tick: vector<u8>): bool {
+        to_uppercase(&mut tick);
+        let tick_str: String = string(tick);
+        table::contains(&deploy_record.record, tick_str)
     }
 
     // ======== TickRecord Read Functions =========
@@ -697,6 +833,80 @@ module smartinscription::movescription {
 
     public fun tick_record_total_transactions(tick_record: &TickRecord): u64 {
         tick_record.total_transactions
+    }
+
+    // ======= TickRecordV2 Read Functions ========
+
+    public fun tick_record_v2_total_supply(tick_record: &TickRecordV2): u64 {
+        tick_record.total_supply
+    }
+
+    public fun tick_record_v2_init_locked_asset(tick_record: &TickRecordV2): u64 {
+        tick_record.init_locked_asset
+    }
+
+    public fun tick_record_v2_mint_factory(tick_record: &TickRecordV2): String {
+        tick_record.mint_factory
+    }
+
+    public fun tick_record_v2_remain(tick_record: &TickRecordV2): u64 {
+        tick_record.stat.remain
+    }
+
+    public fun tick_record_v2_current_supply(tick_record: &TickRecordV2): u64 {
+        tick_record.stat.current_supply
+    }   
+
+    public fun tick_record_v2_total_transactions(tick_record: &TickRecordV2): u64 {
+        tick_record.stat.total_transactions
+    }
+
+    // ======== TickRecordV2 df functions =========
+
+    public fun tick_record_add_df<V: store, W: drop>(tick_record: &mut TickRecordV2, value: V, _witness: W) {
+        type_util::assert_witness<W>(tick_record.mint_factory);
+        let name = type_util::type_to_name<V>();
+        df::add(&mut tick_record.id, name, value);
+    }
+
+    public fun tick_record_remove_df<V: store, W: drop>(tick_record: &mut TickRecordV2, _witness: W) : V {
+        type_util::assert_witness<W>(tick_record.mint_factory);
+        let name = type_util::type_to_name<V>();
+        df::remove(&mut tick_record.id, name)
+    }
+
+    public fun tick_record_borrow_mut_df<V: store, W: drop>(tick_record: &mut TickRecordV2, _witness: W) : &mut V {
+        type_util::assert_witness<W>(tick_record.mint_factory);
+        let name = type_util::type_to_name<V>();
+        df::borrow_mut(&mut tick_record.id, name)
+    }
+
+    public fun tick_record_borrow_df<V: store>(tick_record: &TickRecordV2) : &V{
+        let name = type_util::type_to_name<V>();
+        df::borrow(&tick_record.id, name) 
+    }
+
+    /// Returns 
+    public fun tick_record_exists_df<V: store>(tick_record: &TickRecordV2) : bool {
+        let name = type_util::type_to_name<V>();
+        df::exists_with_type<String, V>(&tick_record.id, name) 
+    }
+
+    // ======== Metadata Functions =========
+
+    public fun new_metadata(content_type: std::string::String, content: vector<u8>) : Metadata {
+        Metadata {
+            content_type,
+            content,
+        }
+    }
+    
+    public fun metadata_content_type(metadata: &Metadata): std::string::String {
+        metadata.content_type
+    }
+
+    public fun metadata_content(metadata: &Metadata): vector<u8> {
+        metadata.content
     }
 
     // ======== Constants functions =========

--- a/sui/sources/string_util.move
+++ b/sui/sources/string_util.move
@@ -33,6 +33,226 @@ module smartinscription::string_util {
         letter >= 65 && letter <= 90
     }
 
+    public fun starts_with(input:&vector<u8>, prefix:&vector<u8>): bool {
+        let input_length = vector::length(input);
+        let prefix_length = vector::length(prefix);
+        if (input_length < prefix_length) {
+            return false
+        };
+        let i = 0;
+        while (i < prefix_length) {
+            if (vector::borrow(input, i) != vector::borrow(prefix, i)) {
+                return false
+            };
+            i = i + 1;
+        };
+        true
+    }
+
+    /// Returns if the input contains the search string and the index of the first match
+    public fun index_of(input:&vector<u8>, search:&vector<u8>): (bool, u64) {
+        let input_length = vector::length(input);
+        let search_length = vector::length(search);
+        if (input_length < search_length) {
+            return (false, 0)
+        };
+        let i = 0;
+        while (i < input_length) {
+            let j = 0;
+            while (j < search_length) {
+                let idx = i + j;
+                if ( idx >= input_length) {
+                    break
+                };
+                if (vector::borrow(input, idx) != vector::borrow(search, j)) {
+                    break
+                };
+                j = j + 1;
+            };
+            if (j == search_length) {
+                return (true, i)
+            };
+            i = i + 1;
+        };
+        (false, 0)
+    }
+
+    /// Returns if the input contains the search string and the index of the last match
+    public fun last_index_of(input:&vector<u8>, search:&vector<u8>): (bool, u64) {
+        let input_length = vector::length(input);
+        let search_length = vector::length(search);
+        if (input_length < search_length) {
+            return (false, 0)
+        };
+        let i = input_length - search_length;
+        while (i >= 0) {
+            let j = 0;
+            while (j < search_length) {
+                let idx = i + j;
+                if ( idx >= input_length) {
+                    break
+                };
+                if (vector::borrow(input, idx) != vector::borrow(search, j)) {
+                    break
+                };
+                j = j + 1;
+            };
+            if (j == search_length) {
+                return (true, i)
+            };
+            if (i == 0){
+                break
+            };
+            i = i - 1;
+        };
+        (false, 0)
+    }
+
+    public fun substring(input:&vector<u8>, start:u64, end:u64): vector<u8> {
+        let length = vector::length(input);
+        if (start >= length) {
+            return vector::empty()
+        };
+        let end = if (end > length) {
+            length
+        } else {
+            end
+        };
+        let result = vector::empty();
+        let i = start;
+        while (i < end) {
+            vector::push_back(&mut result, *vector::borrow(input, i));
+            i = i + 1;
+        };
+        result
+    }
+
+    /// Returns if the input contains any of the chars
+    public fun contains_any(input: &vector<u8>, chars: &vector<u8>): bool {
+        let length = vector::length(input);
+        let chars_length = vector::length(chars);
+        let i = 0;
+        while (i < length) {
+            let j = 0;
+            while (j < chars_length) {
+                if (vector::borrow(input, i) == vector::borrow(chars, j)) {
+                    return true
+                };
+                j = j + 1;
+            };
+            i = i + 1;
+        };
+        false
+    }
+
+    #[test]
+    fun test_index_of() {
+        let input = b"abcabc";
+        let search = b"abc";
+        let (found, index) = index_of(&input, &search);
+        assert!(found, 1);
+        assert!(index == 0, 2);
+
+        let input = b"abcabc";
+        let search = b"bc";
+        let (found, index) = index_of(&input, &search);
+        assert!(found, 3);
+        assert!(index == 1, 4);
+
+        let input = b"abcabc";
+        let search = b"cd";
+        let (found, index) = index_of(&input, &search);
+        assert!(!found, 5);
+        assert!(index == 0, 6);
+
+        let input = b"abcabc";
+        let search = b"abcabc";
+        let (found, index) = index_of(&input, &search);
+        assert!(found, 7);
+        assert!(index == 0, 8);
+
+        let input = b"abcabc";
+        let search = b"abcabcx";
+        let (found, index) = index_of(&input, &search);
+        assert!(!found, 9);
+        assert!(index == 0, 10);
+    }
+
+    #[test]
+    fun test_last_index_of(){
+        let input = b"abcabc";
+        let search = b"abc";
+        let (found, index) = last_index_of(&input, &search);
+        assert!(found, 1);
+        assert!(index == 3, 2);
+
+        let input = b"abcabc";
+        let search = b"bc";
+        let (found, index) = last_index_of(&input, &search);
+        assert!(found, 3);
+        assert!(index == 4, 4);
+
+        let input = b"abcabc";
+        let search = b"cd";
+        let (found, index) = last_index_of(&input, &search);
+        assert!(!found, 5);
+        assert!(index == 0, 6);
+
+        let input = b"abcabc";
+        let search = b"abcabc";
+        let (found, index) = last_index_of(&input, &search);
+        assert!(found, 7);
+        assert!(index == 0, 8);
+
+        let input = b"abcabc";
+        let search = b"abcabcx";
+        let (found, index) = last_index_of(&input, &search);
+        assert!(!found, 9);
+        assert!(index == 0, 10);
+    }
+
+    #[test]
+    fun test_substring(){
+        let input = b"abcabc";
+        let result = substring(&input, 0, 3);
+        assert!(result == b"abc", 1);
+
+        let input = b"abcabc";
+        let result = substring(&input, 0, 6);
+        assert!(result == b"abcabc", 2);
+
+        let input = b"abcabc";
+        let result = substring(&input, 0, 7);
+        assert!(result == b"abcabc", 3);
+
+        let input = b"abcabc";
+        let result = substring(&input, 0, 0);
+        assert!(result == b"", 4);
+
+        let input = b"abcabc";
+        let result = substring(&input, 0, 1);
+        assert!(result == b"a", 5);
+
+        let input = b"abcabc";
+        let result = substring(&input, 1, 3);
+        assert!(result == b"bc", 6);
+    }
+
+    #[test]
+    fun test_contains_any(){
+        let input = b"abcabc";
+        let chars = b"ac";
+        assert!(contains_any(&input, &chars), 1);
+
+        let input = b"abcabc";
+        let chars = b"da";
+        assert!(contains_any(&input, &chars), 2);
+
+        let input = b"abcabc";
+        let chars = b"de";
+        assert!(!contains_any(&input, &chars), 3);
+    }
+
     #[test]
     #[expected_failure(location = Self, abort_code = 1)]
     fun test_is_lowercase() {

--- a/sui/sources/tests/tick_factory_scenario_test.move
+++ b/sui/sources/tests/tick_factory_scenario_test.move
@@ -1,0 +1,71 @@
+#[test_only]
+module smartinscription::tick_factory_scenario_test {
+    use std::option;
+    use sui::clock;
+    use sui::sui::SUI;
+    use sui::coin;
+    use sui::transfer;
+    use sui::test_scenario;
+    use smartinscription::movescription::{Self, Movescription};
+    use smartinscription::tick_factory;
+    use smartinscription::content_type;
+
+    #[test]
+    #[lint_allow(self_transfer)]
+    public fun test_whole_process() {
+
+        let admin = @0xABBA;
+        let usera = @0x1234;
+        let expected_tick_name = b"TEST";
+     
+        let scenario_val = test_scenario::begin(admin);
+        let scenario = &mut scenario_val;
+
+        let c = clock::create_for_testing(test_scenario::ctx(scenario));
+        let start_time_ms = movescription::protocol_start_time_ms();
+        
+        clock::increment_for_testing(&mut c, start_time_ms);
+
+        test_scenario::next_tx(scenario, admin);
+        let move_tick = {
+            movescription::init_for_testing(test_scenario::ctx(scenario));
+            //Need to start a new tx to get the shared object
+            test_scenario::next_tx(scenario, admin);
+            test_scenario::take_shared<movescription::TickRecord>(scenario)
+        };
+
+        test_scenario::next_tx(scenario, admin);
+        {
+            let deploy_record = test_scenario::take_shared<movescription::DeployRecord>(scenario);
+            tick_factory::deploy(&mut deploy_record, test_scenario::ctx(scenario));
+            test_scenario::return_shared(deploy_record);
+        };
+
+        test_scenario::next_tx(scenario, usera);
+        {
+            let tick_name_tick_record = test_scenario::take_shared<movescription::TickRecordV2>(scenario);
+            let test_sui = coin::mint_for_testing<SUI>(tick_factory::init_locked_sui(), test_scenario::ctx(scenario));
+            tick_factory::mint(&mut tick_name_tick_record, test_sui, expected_tick_name, &c, test_scenario::ctx(scenario)); 
+            test_scenario::return_shared(tick_name_tick_record); 
+        };
+        
+        test_scenario::next_tx(scenario, usera);
+        {
+            let first_inscription = test_scenario::take_from_sender<Movescription>(scenario);
+            assert!(movescription::amount(&first_inscription) == 1, 1);
+            //std::debug::print(&first_inscription);
+            assert!(std::ascii::into_bytes(movescription::tick(&first_inscription)) == tick_factory::tick(), 2);
+            let metadata_opt = movescription::metadata(&first_inscription);
+            assert!(option::is_some(&metadata_opt), 3);
+            let metadata = option::destroy_some(metadata_opt);
+            assert!(content_type::is_text(&movescription::metadata_content_type(&metadata)), 4);
+            assert!(movescription::metadata_content(&metadata) == expected_tick_name, 5);
+            transfer::public_transfer(first_inscription, usera);
+        };
+       
+        test_scenario::return_shared(move_tick);
+        clock::destroy_for_testing(c);
+        test_scenario::end(scenario_val);
+    }
+    
+}

--- a/sui/sources/tests/tick_factory_scenario_test.move
+++ b/sui/sources/tests/tick_factory_scenario_test.move
@@ -5,18 +5,23 @@ module smartinscription::tick_factory_scenario_test {
     use sui::sui::SUI;
     use sui::coin;
     use sui::transfer;
+    use sui::tx_context::{TxContext};
     use sui::test_scenario;
-    use smartinscription::movescription::{Self, Movescription};
+    use smartinscription::movescription::{Self, Movescription, TickRecordV2};
     use smartinscription::tick_factory;
     use smartinscription::content_type;
 
+    #[test_only]
+    struct WITNESS has drop{}
+
     #[test]
-    #[lint_allow(self_transfer)]
+    #[lint_allow(self_transfer, share_owned)]
     public fun test_whole_process() {
 
         let admin = @0xABBA;
         let usera = @0x1234;
-        let expected_tick_name = b"TEST";
+        let test_tick_name = b"TEST";
+        let test_tick_total_supply = 100000000u64;
      
         let scenario_val = test_scenario::begin(admin);
         let scenario = &mut scenario_val;
@@ -43,9 +48,10 @@ module smartinscription::tick_factory_scenario_test {
 
         test_scenario::next_tx(scenario, usera);
         {
+            //Mint the TICK movescription, register the TEST tick name
             let tick_name_tick_record = test_scenario::take_shared<movescription::TickRecordV2>(scenario);
             let test_sui = coin::mint_for_testing<SUI>(tick_factory::init_locked_sui(), test_scenario::ctx(scenario));
-            tick_factory::mint(&mut tick_name_tick_record, test_sui, expected_tick_name, &c, test_scenario::ctx(scenario)); 
+            tick_factory::mint(&mut tick_name_tick_record, test_sui, test_tick_name, &c, test_scenario::ctx(scenario)); 
             test_scenario::return_shared(tick_name_tick_record); 
         };
         
@@ -59,13 +65,27 @@ module smartinscription::tick_factory_scenario_test {
             assert!(option::is_some(&metadata_opt), 3);
             let metadata = option::destroy_some(metadata_opt);
             assert!(content_type::is_text(&movescription::metadata_content_type(&metadata)), 4);
-            assert!(movescription::metadata_content(&metadata) == expected_tick_name, 5);
-            transfer::public_transfer(first_inscription, usera);
+            assert!(movescription::metadata_content(&metadata) == test_tick_name, 5);
+            
+            //deploy the TEST tick
+            let deploy_record = test_scenario::take_shared<movescription::DeployRecord>(scenario);
+            let tick_record = movescription::do_deploy_with_witness(&mut deploy_record, first_inscription, test_tick_total_supply, 0, WITNESS{}, test_scenario::ctx(scenario));
+            let test_ms = mint_test_ms(&mut tick_record,1, test_scenario::ctx(scenario));
+            assert!(movescription::check_tick(&test_ms, test_tick_name), 6);
+            transfer::public_transfer(test_ms, usera);
+            transfer::public_share_object(tick_record);
+            test_scenario::return_shared(deploy_record);
         };
+
+        test_scenario::next_tx(scenario, usera);
        
         test_scenario::return_shared(move_tick);
         clock::destroy_for_testing(c);
         test_scenario::end(scenario_val);
     }
     
+    #[test_only]
+    fun mint_test_ms(tick_record: &mut TickRecordV2, amount: u64, ctx: &mut TxContext) : Movescription{
+        movescription::do_mint_with_witness(tick_record, coin::zero<SUI>(ctx), amount, option::none(), WITNESS{}, ctx)
+    }
 }

--- a/sui/sources/tick_factory.move
+++ b/sui/sources/tick_factory.move
@@ -32,7 +32,7 @@ module smartinscription::tick_factory {
 
     #[lint_allow(share_owned)]
     public fun deploy(deploy_record: &mut DeployRecord, ctx: &mut TxContext) {
-        let tick_record = movescription::do_deploy_with_witness(deploy_record, ascii::string(TICK), TOTAL_SUPPLY, INIT_LOCKED_SUI, WITNESS{}, ctx);
+        let tick_record = movescription::internal_deploy_with_witness(deploy_record, ascii::string(TICK), TOTAL_SUPPLY, INIT_LOCKED_SUI, WITNESS{}, ctx);
         let tick_factory = TickFactory{
             tick_names: table::new(ctx),
         };

--- a/sui/sources/tick_factory.move
+++ b/sui/sources/tick_factory.move
@@ -1,0 +1,151 @@
+module smartinscription::tick_factory {
+    use std::ascii::{Self, String};
+    use std::vector;
+    use std::option;
+    use sui::coin::Coin;
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+    use sui::sui::SUI;
+    use sui::table::{Self, Table};
+    use sui::clock::{Self, Clock};
+    use smartinscription::movescription::{Self, DeployRecord, TickRecordV2, Movescription};
+    use smartinscription::content_type;
+    use smartinscription::string_util;
+
+    const TICK: vector<u8> = b"TICK";
+    const TOTAL_SUPPLY: u64 = 0xFFFFFFFFFFFFFFFF; // 18446744073709551615
+    const INIT_LOCKED_SUI: u64 = 10_000000000; // 10 SUI
+    const MAX_TICK_LENGTH: u64 = 32;
+    const MIN_TICK_LENGTH: u64 = 4;
+    const DISALLOWED_TICK_CHARS: vector<u8> = b" .\"'\\/<>?;:[]{}()!@#$%^&*+=|~-,`";
+
+    const ErrorInvalidTickRecord: u64 = 1;
+    const ErrorInvaidTickName: u64 = 2;
+    const ErrorTickNameNotAvailable: u64 = 3;
+
+    struct WITNESS has drop{}
+    
+    struct TickFactory has store{
+        // Tick name -> tick mint time
+        tick_names: Table<String, u64>,
+    }
+
+    #[lint_allow(share_owned)]
+    public fun deploy(deploy_record: &mut DeployRecord, ctx: &mut TxContext) {
+        let tick_record = movescription::do_deploy_with_witness(deploy_record, ascii::string(TICK), TOTAL_SUPPLY, INIT_LOCKED_SUI, WITNESS{}, ctx);
+        let tick_factory = TickFactory{
+            tick_names: table::new(ctx),
+        };
+        //TODO migrate the deployed tick names to the new tick factory
+        movescription::tick_record_add_df(&mut tick_record, tick_factory, WITNESS{});
+        transfer::public_share_object(tick_record);
+    }
+
+    public fun do_mint(
+        tick_record: &mut TickRecordV2,
+        init_locked_coin: Coin<SUI>,
+        tick_name: vector<u8>,
+        clock: &Clock,
+        ctx: &mut TxContext) : Movescription {
+        assert!(movescription::check_tick_record(tick_record, TICK), ErrorInvalidTickRecord);
+        assert!(is_tick_name_valid(tick_name), ErrorInvaidTickName);
+        assert!(is_tick_name_available(tick_record, tick_name), ErrorTickNameNotAvailable);
+
+        let now = clock::timestamp_ms(clock);
+        let tick_name_str = ascii::string(tick_name);
+        let tick_factory = movescription::tick_record_borrow_mut_df<TickFactory, WITNESS>(tick_record, WITNESS{});
+        table::add(&mut tick_factory.tick_names, tick_name_str, now);
+        //TODO record mint time to the metadata
+        let metadata = content_type::new_ascii_metadata(&tick_name_str);
+        movescription::do_mint_with_witness(tick_record, init_locked_coin, 1, option::some(metadata), WITNESS{}, ctx)
+    }
+
+    #[lint_allow(self_transfer)]
+    public entry fun mint(
+        tick_record: &mut TickRecordV2,
+        init_locked_coin: Coin<SUI>,
+        tick_name: vector<u8>,
+        clock: &Clock,
+        ctx: &mut TxContext) {
+        let ms = do_mint(tick_record, init_locked_coin, tick_name, clock, ctx);
+        transfer::public_transfer(ms, tx_context::sender(ctx));
+    }
+
+    /// Check if the tick name is available, if it has bean minted or deployed or reserved, it is not available
+    public fun is_tick_name_available(tick_record: &mut TickRecordV2, tick_name: vector<u8>) : bool {
+        string_util::to_uppercase(&mut tick_name);
+        let tick_name_str = ascii::string(tick_name);
+        let tick_factory = movescription::tick_record_borrow_df<TickFactory>(tick_record);
+        !table::contains(&tick_factory.tick_names, tick_name_str) && !is_tick_name_reserved(ascii::into_bytes(tick_name_str))
+    }
+
+    public fun is_tick_name_reserved(tick_name: vector<u8>) : bool {
+        string_util::to_uppercase(&mut tick_name);
+        tick_name == b"TICK" || tick_name == b"NAME"
+    }
+
+    /// Check if the tick name is valid
+    public fun is_tick_name_valid(tick_name: vector<u8>) : bool {
+        let tick_len = vector::length(&tick_name);
+        if(tick_len < MIN_TICK_LENGTH || tick_len > MAX_TICK_LENGTH) {
+            return false
+        };
+        if (string_util::contains_any(&tick_name, &DISALLOWED_TICK_CHARS)){
+            return false
+        };
+        let str_opt = ascii::try_string(tick_name);
+        if(option::is_none(&str_opt)) {
+            return false
+        };
+        let tick_name = option::destroy_some(str_opt);
+        ascii::all_characters_printable(&tick_name)
+    }
+
+    // ===== Constants functions =====
+
+    public fun tick() : vector<u8> {
+        TICK
+    }
+    
+    public fun init_locked_sui() : u64 {
+        INIT_LOCKED_SUI
+    }
+
+    #[test]
+    fun test_is_tick_name_valid() {
+        assert!(!is_tick_name_valid(b"abc"), 1);
+        assert!(!is_tick_name_valid(b"123456789012345678901234567890123"), 1);
+        assert!(is_tick_name_valid(b"abcd"), 2);
+        assert!(is_tick_name_valid(b"ab_d"), 2);
+        assert!(!is_tick_name_valid(b"abc!"), 3);
+        assert!(!is_tick_name_valid(b"abc "), 4);
+        assert!(!is_tick_name_valid(b"abc."), 5);
+        assert!(!is_tick_name_valid(b"abc@"), 6);
+        assert!(!is_tick_name_valid(b"abc#"), 7);
+        assert!(!is_tick_name_valid(b"abc$"), 8);
+        assert!(!is_tick_name_valid(b"abc&"), 9);
+        assert!(!is_tick_name_valid(b"abc="), 10);
+        assert!(!is_tick_name_valid(b"abc+"), 11);
+        assert!(!is_tick_name_valid(b"abc-"), 12);
+        assert!(!is_tick_name_valid(b"abc*"), 13);
+        assert!(!is_tick_name_valid(b"abc/"), 14);
+        assert!(!is_tick_name_valid(b"abc\\"), 15);
+        assert!(!is_tick_name_valid(b"abc|"), 16);
+        assert!(!is_tick_name_valid(b"abc<"), 17);
+        assert!(!is_tick_name_valid(b"abc>"), 18);
+        assert!(!is_tick_name_valid(b"abc,"), 19);
+        assert!(!is_tick_name_valid(b"abc?"), 20);
+        assert!(!is_tick_name_valid(b"abc;"), 21);
+        assert!(!is_tick_name_valid(b"abc:"), 22);
+        assert!(!is_tick_name_valid(b"abc["), 23);
+        assert!(!is_tick_name_valid(b"abc]"), 24);
+        assert!(!is_tick_name_valid(b"abc{"), 25);
+        assert!(!is_tick_name_valid(b"abc}"), 26);
+        assert!(!is_tick_name_valid(b"abc("), 27);
+        assert!(!is_tick_name_valid(b"abc)"), 28);
+        assert!(!is_tick_name_valid(b"abc'"), 29);
+        assert!(!is_tick_name_valid(b"abc\""), 30);
+        assert!(!is_tick_name_valid(b"abc`"), 31);
+        assert!(!is_tick_name_valid(b"abc~"), 32);
+    }
+}

--- a/sui/sources/type_util.move
+++ b/sui/sources/type_util.move
@@ -1,0 +1,84 @@
+module smartinscription::type_util{
+    use std::type_name;
+    use std::vector;
+    use std::ascii::{Self, String};
+    use smartinscription::string_util;
+
+    const ErrorInvalidStruct : u64 = 1;
+    const ErrorInvalidWitness : u64 = 2;
+
+    const WITNESS_STRUCT_NAME : vector<u8> = b"WITNESS";
+    const SPLIT : vector<u8> = b"::";
+    
+    public fun type_to_name<T>() : String {
+        type_name::into_string(type_name::get_with_original_ids<T>())
+    }
+
+    public fun is_witness<T>() : bool {
+        let struct_name = struct_name<T>();
+        ascii::into_bytes(struct_name) == WITNESS_STRUCT_NAME
+    }
+
+    public fun assert_witness<T>(expect_module: String) {
+        assert!(check_witness<T>(expect_module), ErrorInvalidWitness);
+    }
+
+    /// Checks if the witness of a type is the expected module.
+    public fun check_witness<T>(expect_module: String) : bool {
+        let type_name = ascii::into_bytes(type_to_name<T>());
+        let expect_name = ascii::into_bytes(expect_module);
+        vector::append(&mut expect_name, SPLIT);
+        vector::append(&mut expect_name, WITNESS_STRUCT_NAME);
+        type_name == expect_name
+    }
+
+    /// Returns the module address and name of a type.
+    public fun module_id<T>() : String {
+        let type_name = ascii::into_bytes(type_to_name<T>());
+        let (found, index) = string_util::last_index_of(&type_name, &SPLIT);
+        assert!(found, ErrorInvalidStruct);
+        ascii::string(string_util::substring(&type_name, 0, index))
+    }
+
+    /// Returns the struct name of a type.
+    public fun struct_name<T>() : String {
+        let type_name = ascii::into_bytes(type_to_name<T>());
+        let (found, index) = string_util::last_index_of(&type_name, &SPLIT);
+        assert!(found, ErrorInvalidStruct);
+        ascii::string(string_util::substring(&type_name, index + 2, vector::length(&type_name)))
+    }
+
+    #[test_only]
+    struct WITNESS has drop{}
+
+    #[test]
+    fun test_module_id() {
+        let module_id = module_id<WITNESS>();
+        //std::debug::print(&module_id);
+        let expect_module_id = b"0000000000000000000000000000000000000000000000000000000000000000";
+        vector::append(&mut expect_module_id, SPLIT);
+        vector::append(&mut expect_module_id, b"type_util");
+        let expect_module_id = ascii::string(expect_module_id);
+        //std::debug::print(&expect_module_id);
+        assert!(module_id == expect_module_id, 1);
+    }
+
+    #[test]
+    fun test_struct_name() {
+        let struct_name = struct_name<WITNESS>();
+        let expect_struct_name = ascii::string(WITNESS_STRUCT_NAME);
+        assert!(struct_name == expect_struct_name, 1);
+    }
+
+    #[test]
+    #[expected_failure]
+    fun test_struct_name_failed(){
+        struct_name<u64>();
+    }
+
+    #[test]
+    #[expected_failure]
+    fun test_module_id_failed(){
+        module_id<u64>();
+    }
+}


### PR DESCRIPTION
1. 提供通过 mint factory 扩展机制，将 mint 的策略从 movescription 模块迁移出去。
2. 实现 tick_factory 用来 mint TICK Movescription。
3. 实现 Metadata 以及 content_type。

## 相关 MIP

* https://github.com/movescriptions/MIPs/issues/16
* https://github.com/movescriptions/MIPs/issues/12