### PR TITLE
Define TextMetadata and recycle name when burn

### DIFF
--- a/sui/sources/metadata.move
+++ b/sui/sources/metadata.move
@@ -1,0 +1,85 @@
+/// This module contains the metadata struct, which is used to store metadata in the BCS.
+module smartinscription::metadata {
+    use std::option;
+    use sui::bcs;
+    use smartinscription::movescription::{Self, Metadata};
+    use smartinscription::content_type;
+    use smartinscription::type_util;
+
+    const ErrorInvalidMetadata: u64 = 1;
+    const ErrorInvalidMetadataType: u64 = 2;
+    
+    /// BCS text metadata, which is a string with a timestamp and miner address
+    /// We use vector<u8> instead of String because we want to be able to support `ascii::String` and `string::String`.
+    struct TextMetadata has store, copy, drop{
+        text: vector<u8>,
+        timestamp_ms: u64,
+        miner: address,
+    }
+
+    public fun new_ascii_metadata(text: std::ascii::String, timestamp_ms: u64, miner: address): TextMetadata {
+        TextMetadata{
+            text: std::ascii::into_bytes(text),
+            timestamp_ms,
+            miner,
+        }
+    }
+
+    public fun new_string_metadata(text: std::string::String, timestamp_ms: u64, miner: address): TextMetadata{
+        TextMetadata{
+            text: *std::string::bytes(&text),
+            timestamp_ms,
+            miner,
+        }
+    }
+
+    public fun decode_text_metadata(metadata: &Metadata) : TextMetadata {
+        let ct = movescription::metadata_content_type(metadata);
+        let content = movescription::metadata_content(metadata);
+        assert!(content_type::is_bcs(&ct), ErrorInvalidMetadata);
+        let type_name = content_type::get_bcs_type_name(&ct);
+        let type_name = option::destroy_with_default(type_name, std::ascii::string(b""));
+        assert!(type_name == type_util::type_to_name<TextMetadata>(), ErrorInvalidMetadataType);
+        let bcs = bcs::new(content);
+        let text = bcs::peel_vec_u8(&mut bcs);
+        let timestamp_ms = bcs::peel_u64(&mut bcs);
+        let miner = bcs::peel_address(&mut bcs);
+        TextMetadata{
+            text,
+            timestamp_ms,
+            miner
+        }
+    }
+
+    public fun unpack_text_metadata(text_metadata: TextMetadata): (vector<u8>, u64, address){
+        let TextMetadata{text, timestamp_ms, miner} = text_metadata;
+        (text, timestamp_ms, miner)
+    }
+
+    public fun text_metadata_text(text_metadata: &TextMetadata) : &vector<u8>{
+        &text_metadata.text
+    }
+
+    public fun text_metadata_timestamp(text_metadata: &TextMetadata): u64{
+        text_metadata.timestamp_ms
+    }
+
+    public fun text_metadata_miner(text_metadata: &TextMetadata) : address{
+        text_metadata.miner
+    }
+    
+
+    #[test]
+    fun test_text_metadata(){
+        let text = std::ascii::string(b"test");
+        let timestamp_ms = 10000;
+        let miner = @0xABCD;
+
+        let text_metata = new_ascii_metadata(text , timestamp_ms, miner);
+        let metadata = content_type::new_bcs_metadata(&text_metata);
+        let decoded_text_metadata = decode_text_metadata(&metadata);
+        assert!(std::ascii::string(decoded_text_metadata.text) == text, 1);
+        assert!(decoded_text_metadata.timestamp_ms == timestamp_ms, 2);
+        assert!(decoded_text_metadata.miner == miner, 3); 
+    }
+}

--- a/sui/sources/tests/tick_factory_scenario_test.move
+++ b/sui/sources/tests/tick_factory_scenario_test.move
@@ -11,6 +11,7 @@ module smartinscription::tick_factory_scenario_test {
     use smartinscription::tick_factory;
     use smartinscription::scenario_test;
     use smartinscription::epoch_bus_factory;
+    use smartinscription::metadata;
 
     #[test_only]
     struct WITNESS has drop{}
@@ -21,7 +22,8 @@ module smartinscription::tick_factory_scenario_test {
 
         let admin = @0xABBA;
         let usera = @0x1234;
-        let test_tick_name = b"TEST";
+        let test_tick_name1 = b"TEST1";
+        let test_tick_name2 = b"TEST2";
         let test_tick_total_supply = 100000000u64;
      
         let scenario_val = test_scenario::begin(admin);
@@ -30,26 +32,40 @@ module smartinscription::tick_factory_scenario_test {
         let (clock, deploy_record, tick_tick_record, move_tick_record) = scenario_test::init_for_testing(scenario); 
 
         test_scenario::next_tx(scenario, usera);
-        let test_tick_name_movescription = {
-            //Mint a TICK movescription, register test_tick_name 
+        let test_tick_name1_movescription = {
+            //Mint a TICK movescription, register test_tick_name1 
             let locked_move = epoch_bus_factory::mint_for_testing(&mut move_tick_record, tick_factory::init_locked_move(), balance::zero(), test_scenario::ctx(scenario));
-            tick_factory::do_mint(&mut tick_tick_record, locked_move, test_tick_name, &clock, test_scenario::ctx(scenario)) 
+            tick_factory::do_mint(&mut tick_tick_record, locked_move, test_tick_name1, &clock, test_scenario::ctx(scenario)) 
         };
         
         {
-            assert!(movescription::amount(&test_tick_name_movescription) == 1, 1);
-            //std::debug::print(&test_tick_name_movescription);
-            assert!(std::ascii::into_bytes(movescription::tick(&test_tick_name_movescription)) == tick_factory::tick(), 2);
-            let tick_name_metadata = tick_factory::decode_metadata(&test_tick_name_movescription);
-            assert!(tick_factory::metadata_tick_name(&tick_name_metadata) == std::ascii::string(test_tick_name), 5);
-            assert!(tick_factory::metadata_miner(&tick_name_metadata) == usera, 6);
+            assert!(movescription::amount(&test_tick_name1_movescription) == 1, 1);
+            //std::debug::print(&test_tick_name1_movescription);
+            assert!(std::ascii::into_bytes(movescription::tick(&test_tick_name1_movescription)) == tick_factory::tick(), 2);
+            let metadata = option::destroy_some(movescription::metadata(&test_tick_name1_movescription));
+            let tick_name_metadata = metadata::decode_text_metadata(&metadata);
+            assert!(metadata::text_metadata_text(&tick_name_metadata) == &test_tick_name1, 5);
+            assert!(metadata::text_metadata_miner(&tick_name_metadata) == usera, 6);
             
             //deploy the TEST tick
-            let tick_record = tick_factory::do_deploy(&mut deploy_record, &mut tick_tick_record, test_tick_name_movescription, test_tick_total_supply, true, WITNESS{}, test_scenario::ctx(scenario));
+            let tick_record = tick_factory::do_deploy(&mut deploy_record, &mut tick_tick_record, test_tick_name1_movescription, test_tick_total_supply, true, WITNESS{}, test_scenario::ctx(scenario));
             let test_ms = mint_test_ms(&mut tick_record,1, test_scenario::ctx(scenario));
-            assert!(movescription::check_tick(&test_ms, test_tick_name), 6);
+            assert!(movescription::check_tick(&test_ms, test_tick_name1), 6);
             transfer::public_transfer(test_ms, usera);
             transfer::public_share_object(tick_record);
+        };
+
+        test_scenario::next_tx(scenario, usera);
+        //test burn tick name and recycle
+        {
+            //Mint a TICK movescription, register test_tick_name2 
+            let locked_move = epoch_bus_factory::mint_for_testing(&mut move_tick_record, tick_factory::init_locked_move(), balance::zero(), test_scenario::ctx(scenario));
+            let test_tick_name2_movescription = tick_factory::do_mint(&mut tick_tick_record, locked_move, test_tick_name2, &clock, test_scenario::ctx(scenario)); 
+
+            assert!(!tick_factory::is_tick_name_available(&tick_tick_record, test_tick_name2), 7);
+            test_scenario::next_tx(scenario, usera);
+            tick_factory::burn(&mut tick_tick_record, test_tick_name2_movescription,test_scenario::ctx(scenario));
+            assert!(tick_factory::is_tick_name_available(&tick_tick_record, test_tick_name2), 8);
         };
 
         clock::destroy_for_testing(clock);


### PR DESCRIPTION
1. 抽取出通用的 TextMetadata，通过 BCS 序列化，用在 TICK 和 NAME 中。
2. 实现 burn 的时候回收 TICK 和 NAME。


TODO
1. 收取部署费用。
2. BURN 的时候收取一定费用？